### PR TITLE
Fix incorrect error message in quickreplace

### DIFF
--- a/codes/chapter2/quickreplace/src/main.rs
+++ b/codes/chapter2/quickreplace/src/main.rs
@@ -41,7 +41,7 @@ fn main() {
             eprintln!(
                 "{} failed to write to file '{}': {:?}",
                 "Error:".red().bold(),
-                args.filename,
+                args.output,
                 e
             );
             std::process::exit(1);


### PR DESCRIPTION
## Summary
- point file writing error messages at the output file

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6841220550cc8320a6506f49e0f5730e